### PR TITLE
Fix closingTag. </h1> => </a>

### DIFF
--- a/lib/handler-util.js
+++ b/lib/handler-util.js
@@ -7,7 +7,7 @@ function handleLogout(req, res) {
   });
   res.end('<!DOCTYPE html><html lang="ja"><body>' +
     '<h1>ログアウトしました</h1>' +
-    '<a href="/posts">ログイン</h1>' +
+    '<a href="/posts">ログイン</a>' +
     '</body></html>');
 }
 


### PR DESCRIPTION
恐らく誤りだと思われる部分を修正しました。閉じタグを\</h1>から\</a>に修正。アプリ上で動作に問題が無いのはなぜでしょう。ブラウザがレンダリング時に修正しているっぽい？